### PR TITLE
Add copy to the default proc for hash.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,12 @@
 require "bundler/gem_tasks"
 
+require 'rspec/core/rake_task'
+
+namespace :test do
+  desc "Run the specs"
+  task :spec do
+    RSpec::Core::RakeTask.new("test:spec")
+  end
+end
+
+task :default => "test:spec"

--- a/lib/sinatra/strong-params.rb
+++ b/lib/sinatra/strong-params.rb
@@ -27,6 +27,9 @@ module Sinatra
             @params = @params.select do |param, _value|
               passable.include?(param.to_sym)
             end
+
+            # copy Hash#default_proc
+            @params.tap { |h| h.default_proc = @_params.default_proc.dup rescue nil }
           end
         end
       end

--- a/sinatra-strong-params.gemspec
+++ b/sinatra-strong-params.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rack-test"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+ENV['RACK_ENV'] = 'test'
+
+require 'rspec'
+require_relative 'test_helper'
+
+RSpec.configure do |config|
+  config.mock_framework = :rspec
+  config.include TestHelper
+end

--- a/spec/strong-params_spec.rb
+++ b/spec/strong-params_spec.rb
@@ -1,0 +1,68 @@
+require_relative 'spec_helper'
+require 'json'
+
+$:.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'sinatra/strong-params'
+
+describe Sinatra::StrongParams do
+
+  context "using allows filter" do
+
+    let(:request_params) { { id: 'id', action: 'action', not_allows: 'not_allows' } }
+
+    it 'supports accessing params with string keys' do
+      actual_params = nil
+      mock_app do
+        register Sinatra::StrongParams
+        get '/', allows: [:id, :action] { actual_params = params }
+      end
+
+      get '/', request_params
+      expect(actual_params['id']).to eq request_params[:id]
+      expect(actual_params['action']).to eq request_params[:action]
+      expect(actual_params['not_allows']).to eq nil
+    end
+
+    it 'supports accessing params with symbol keys' do
+      actual_params = nil
+      mock_app do
+        register Sinatra::StrongParams
+        get '/', allows: [:id, :action] { actual_params = params }
+      end
+
+      get '/', request_params
+      expect(actual_params[:id]).to eq request_params[:id]
+      expect(actual_params[:action]).to eq request_params[:action]
+      expect(actual_params[:not_allows]).to eq nil
+    end
+  end
+
+  context "using needs filter" do
+    it 'supports accessing params with string keys' do
+      actual_params = nil
+      mock_app do
+        register Sinatra::StrongParams
+        get '/', needs: [:id, :action] { actual_params = params }
+      end
+      params = { id: 'id', action: 'action' }
+
+      get '/', params
+      expect(actual_params['id']).to eq params[:id]
+      expect(actual_params['action']).to eq params[:action]
+    end
+
+    it 'supports accessing params with symbol keys' do
+      actual_params = nil
+      mock_app do
+        register Sinatra::StrongParams
+        get '/', needs: [:id, :action] { actual_params = params }
+      end
+      params = { id: 'id', action: 'action' }
+
+      get '/', params
+      expect(actual_params[:id]).to eq params[:id]
+      expect(actual_params[:action]).to eq params[:action]
+    end
+  end
+
+end

--- a/spec/strong-params_spec.rb
+++ b/spec/strong-params_spec.rb
@@ -8,33 +8,68 @@ describe Sinatra::StrongParams do
 
   context "using allows filter" do
 
-    let(:request_params) { { id: 'id', action: 'action', not_allows: 'not_allows' } }
+    context "with no nested params" do
 
-    it 'supports accessing params with string keys' do
-      actual_params = nil
-      mock_app do
-        register Sinatra::StrongParams
-        get '/', allows: [:id, :action] { actual_params = params }
+      let(:request_params) { { id: 'id', action: 'action', not_allows: 'not_allows' } }
+
+      it 'supports accessing params with string keys' do
+        actual_params = nil
+        mock_app do
+          register Sinatra::StrongParams
+          get '/', allows: [:id, :action] { actual_params = params }
+        end
+
+        get '/', request_params
+        expect(actual_params['id']).to eq request_params[:id]
+        expect(actual_params['action']).to eq request_params[:action]
+        expect(actual_params['not_allows']).to eq nil
       end
 
-      get '/', request_params
-      expect(actual_params['id']).to eq request_params[:id]
-      expect(actual_params['action']).to eq request_params[:action]
-      expect(actual_params['not_allows']).to eq nil
-    end
+      it 'supports accessing params with symbol keys' do
+        actual_params = nil
+        mock_app do
+          register Sinatra::StrongParams
+          get '/', allows: [:id, :action] { actual_params = params }
+        end
 
-    it 'supports accessing params with symbol keys' do
-      actual_params = nil
-      mock_app do
-        register Sinatra::StrongParams
-        get '/', allows: [:id, :action] { actual_params = params }
+        get '/', request_params
+        expect(actual_params[:id]).to eq request_params[:id]
+        expect(actual_params[:action]).to eq request_params[:action]
+        expect(actual_params[:not_allows]).to eq nil
       end
 
-      get '/', request_params
-      expect(actual_params[:id]).to eq request_params[:id]
-      expect(actual_params[:action]).to eq request_params[:action]
-      expect(actual_params[:not_allows]).to eq nil
     end
+
+    context "with nested params" do
+
+      let(:request_params) { { id: [ { in_array: 'in_array'} ], action: { nested_hash: 'nested_hash'} }}
+
+      it 'supports accessing params with string keys' do
+        actual_params = nil
+        mock_app do
+          register Sinatra::StrongParams
+          get '/', allows: [:id, :action] { actual_params = params }
+        end
+
+        get '/', request_params
+        expect(actual_params['id'][0]['in_array']).to eq request_params[:id][0][:in_array]
+        expect(actual_params['action']['nested_hash']).to eq request_params[:action][:nested_hash]
+      end
+
+      it 'supports accessing params with symbol keys' do
+        actual_params = nil
+        mock_app do
+          register Sinatra::StrongParams
+          get '/', allows: [:id, :action] { actual_params = params }
+        end
+
+        get '/', request_params
+        expect(actual_params[:id][0][:in_array]).to eq request_params[:id][0][:in_array]
+        expect(actual_params[:action][:nested_hash]).to eq request_params[:action][:nested_hash]
+      end
+
+    end
+
   end
 
   context "using needs filter" do

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -1,0 +1,20 @@
+require 'rack/test'
+
+module TestHelper
+  include Rack::Test::Methods
+
+  def mock_app(&block)
+    @app  = Sinatra.new(Sinatra::Base) do
+      class_eval(&block)
+    end
+  end
+
+  def app
+    @app
+  end
+  
+  def json
+    JSON.parse(last_response.body, :symbolize_names => true)
+  end
+
+end


### PR DESCRIPTION
When I using the allows filter, I can not access the value of a parameter through a symbol.
So I add to copy the default proc for hash.