### PR TITLE
Keep only the allowed params in the params hash

### DIFF
--- a/lib/sinatra/strong-params.rb
+++ b/lib/sinatra/strong-params.rb
@@ -25,14 +25,9 @@ module Sinatra
             globals  = settings.globally_allowed_parameters
             passable = (globals | passable).map(&:to_sym) # make sure it's a symbol
 
-            # Select only the allowed parameters.
-            @params = @params.select do |param, _value|
-              passable.include?(param.to_sym)
-            end
-
-            # Copy Sinatra's default proc to allow indifferent access.
-            @params.tap do |params|
-              params.default_proc = @_params.default_proc.dup rescue nil
+            # Keep only the allowed parameters.
+            @params = @params.delete_if do |param, _value|
+              !passable.include?(param.to_sym)
             end
           end
         end


### PR DESCRIPTION
Hi,

I tried to contribute to the project but the specs were failing and it was not a false negative. The indifferent access was broken because we were doing a `select` in the `@params` hash, this creates a new hash which loose the indifferent access behaviour. The `delete_if` doesn't create a new hash.

Perhaps you could consider adding a CI like Travis to this project, it would catch these issues.