### PR TITLE
Improve needs error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 A really naive parameter filtering implementation for Sinatra.
 
-
-
 ## Installation
 
 Add this line to your application's Gemfile:
 
-    gem 'sinatra-strong-params', :require => 'sinatra/strong-params'
+    gem 'sinatra-strong-params', require: 'sinatra/strong-params'
 
 And then execute:
 
@@ -18,7 +16,7 @@ Or install it yourself as:
 
     $ gem install sinatra-strong-params
 
-If you are using a Modular Sinatra application such as `class FooApp < Sinatra::Base` you must include any desired extensions explicitly within your Sinatra application
+If you are using a Modular Sinatra application such as `class MyApp < Sinatra::Base` you must include any desired extensions explicitly within your Sinatra application:
 
 ```ruby
 register Sinatra::StrongParams
@@ -27,8 +25,6 @@ register Sinatra::StrongParams
 ## Usage
 
 This gem adds two filters to Sinatra routes: `allows` and `needs`.
-
-
 
 ### Allows
 
@@ -40,10 +36,7 @@ get '/', allows: [:id, :action] do
 end
 ```
 
-`allows` modifies the parameters available in the request scope, so
-beware, though it stashes unmodified params in @_params.
-
-
+`allows` modifies the parameters available in the request scope keeping just the allowed params.
 
 ### Needs
 
@@ -56,9 +49,9 @@ end
 ```
 
 `needs` does not modify the parameters available to the request scope
-and raises a RequiredParamMissing error if a needed param is missing.
+but raises a `RequiredParamMissing` error if a needed param is missing.
 
-Catching a missing parameter:
+Catching a missing parameter error:
 
 ```ruby
 error RequiredParamMissing do
@@ -66,23 +59,20 @@ error RequiredParamMissing do
 end
 ```
 
-
-
-### Both
+### Allows and Needs
 
 Wanna get super restrictive? Can do.
 
 ```ruby
-post '/login', allows: [:email, :password], needs: [:email, :password] do
+post '/login', needs: [:email, :password], allows: [:name] do
   # handle yo business
 end
 ```
-
 
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/sinatra-strong-params/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
+3. Commit your changes with tests (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request

--- a/lib/sinatra/strong-params.rb
+++ b/lib/sinatra/strong-params.rb
@@ -46,32 +46,29 @@ module Sinatra
       #
       app.set(:needs) do |*needed|
         condition do
-          if @params.nil? || @params.empty? && !needed.empty?
-            fail RequiredParamMissing, settings.missing_parameter_message
-          else
-            needed     = needed.map(&:to_sym) # make sure it's a symbol
-            @_needed   = needed
-            sym_params = @params.dup
+          needed     = needed.map(&:to_sym) # make sure it's a symbol
+          @_needed   = needed
+          sym_params = @params.dup
 
-            # symbolize the keys so we know what we're looking at
-            sym_params.keys.each do |key|
-              sym_params[(key.to_sym rescue key) || key] = sym_params.delete(key)
-            end
+          # symbolize the keys so we know what we're looking at
+          sym_params.keys.each do |key|
+            sym_params[(key.to_sym rescue key) || key] = sym_params.delete(key)
+          end
 
-            if needed.any? { |key| sym_params[key].nil? || sym_params[key].empty? }
-              fail RequiredParamMissing, settings.missing_parameter_message
-            end
+          missing_params = needed.select { |key| sym_params[key].nil? || sym_params[key].empty? }
+          if missing_params.any?
+            fail RequiredParamMissing, "#{settings.missing_parameter_message} #{missing_params.join(', ')}"
           end
         end
       end
 
       # These will always pass through the 'allows' method
-      #   and will be mapped to symbols. I often use [:redirect_to, :_csrf] here
-      #   because I always want them to pass through for later processing
+      # and will be mapped to symbols. I often use [:redirect_to, :_csrf] here
+      # because I always want them to pass through for later processing
       app.set :globally_allowed_parameters, []
 
       # The default message when RequiredParamMissing is raised.
-      app.set :missing_parameter_message, 'One or more required parameters were missing.'
+      app.set :missing_parameter_message, 'One or more required parameters were missing:'
 
       # Change the default behavior for missing parameters by overriding this route.
       # For example...

--- a/spec/strong-params_spec.rb
+++ b/spec/strong-params_spec.rb
@@ -3,7 +3,6 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 require_relative 'spec_helper'
-require 'json'
 require 'sinatra/strong-params'
 
 describe Sinatra::StrongParams do
@@ -86,6 +85,36 @@ describe Sinatra::StrongParams do
       get '/', request_params
       expect(actual_params[:id]).to eq request_params[:id]
       expect(actual_params[:action]).to eq request_params[:action]
+    end
+
+    context 'with missing params' do
+      context 'and empty request' do
+        let(:request_params) { nil }
+
+        it 'return an error message with the missing keys on it' do
+          mock_registerd_app do
+            get '/', needs: [:id, :name, :action] { }
+          end
+
+          get '/', request_params
+          expect(last_response.status).to eq 400
+          expect(last_response.body).to eq('One or more required parameters were missing: id, name, action')
+        end
+      end
+
+      context 'and some params are present' do
+        let(:request_params) { { id: 'id', name: '' } }
+
+        it 'return an error message with the missing keys on it' do
+          mock_registerd_app do
+            get '/', needs: [:id, :name, :action] { }
+          end
+
+          get '/', request_params
+          expect(last_response.status).to eq 400
+          expect(last_response.body).to eq('One or more required parameters were missing: name, action')
+        end
+      end
     end
   end
 

--- a/spec/strong-params_spec.rb
+++ b/spec/strong-params_spec.rb
@@ -7,14 +7,13 @@ require 'json'
 require 'sinatra/strong-params'
 
 describe Sinatra::StrongParams do
-  context "using allows filter" do
-    context "with no nested params" do
+  context 'using allows filter' do
+    context 'with no nested params' do
       let(:request_params) { { id: 'id', action: 'action', not_allows: 'not_allows' } }
 
       it 'supports accessing params with string keys' do
         actual_params = nil
-        mock_app do
-          register Sinatra::StrongParams
+        mock_registerd_app do
           get '/', allows: [:id, :action] { actual_params = params }
         end
 
@@ -26,8 +25,7 @@ describe Sinatra::StrongParams do
 
       it 'supports accessing params with symbol keys' do
         actual_params = nil
-        mock_app do
-          register Sinatra::StrongParams
+        mock_registerd_app do
           get '/', allows: [:id, :action] { actual_params = params }
         end
 
@@ -38,13 +36,12 @@ describe Sinatra::StrongParams do
       end
     end
 
-    context "with nested params" do
+    context 'with nested params' do
       let(:request_params) { { id: [ { in_array: 'in_array'} ], action: { nested_hash: 'nested_hash'} }}
 
       it 'supports accessing params with string keys' do
         actual_params = nil
-        mock_app do
-          register Sinatra::StrongParams
+        mock_registerd_app do
           get '/', allows: [:id, :action] { actual_params = params }
         end
 
@@ -55,8 +52,7 @@ describe Sinatra::StrongParams do
 
       it 'supports accessing params with symbol keys' do
         actual_params = nil
-        mock_app do
-          register Sinatra::StrongParams
+        mock_registerd_app do
           get '/', allows: [:id, :action] { actual_params = params }
         end
 
@@ -67,47 +63,45 @@ describe Sinatra::StrongParams do
     end
   end
 
-  context "using needs filter" do
+  context 'using needs filter' do
+    let(:request_params) { { id: 'id', action: 'action' } }
+
     it 'supports accessing params with string keys' do
       actual_params = nil
-      mock_app do
-        register Sinatra::StrongParams
+      mock_registerd_app do
         get '/', needs: [:id, :action] { actual_params = params }
       end
-      params = { id: 'id', action: 'action' }
 
-      get '/', params
-      expect(actual_params['id']).to eq params[:id]
-      expect(actual_params['action']).to eq params[:action]
+      get '/', request_params
+      expect(actual_params['id']).to eq request_params[:id]
+      expect(actual_params['action']).to eq request_params[:action]
     end
 
     it 'supports accessing params with symbol keys' do
       actual_params = nil
-      mock_app do
-        register Sinatra::StrongParams
+      mock_registerd_app do
         get '/', needs: [:id, :action] { actual_params = params }
       end
-      params = { id: 'id', action: 'action' }
 
-      get '/', params
-      expect(actual_params[:id]).to eq params[:id]
-      expect(actual_params[:action]).to eq params[:action]
+      get '/', request_params
+      expect(actual_params[:id]).to eq request_params[:id]
+      expect(actual_params[:action]).to eq request_params[:action]
     end
   end
 
-  context "using allows and needs filter" do
-        it 'supports accessing params with string keys' do
+  context 'using allows and needs filter' do
+    let(:request_params) { { id: 'id', action: 'action', resource: 'resource', not_allows: 'not_allows' } }
+
+    it 'supports accessing params with string keys' do
       actual_params = nil
-      mock_app do
-        register Sinatra::StrongParams
+      mock_registerd_app do
         get '/', needs: [:id, :action], allows: [:resource] { actual_params = params }
       end
-      params = { id: 'id', action: 'action', resource: 'resource', not_allows: 'not_allows' }
 
-      get '/', params
-      expect(actual_params['id']).to eq params[:id]
-      expect(actual_params['action']).to eq params[:action]
-      expect(actual_params['resource']).to eq params[:resource]
+      get '/', request_params
+      expect(actual_params['id']).to eq request_params[:id]
+      expect(actual_params['action']).to eq request_params[:action]
+      expect(actual_params['resource']).to eq request_params[:resource]
       expect(actual_params['not_allows']).to eq nil
     end
   end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -11,6 +11,13 @@ module TestHelper
     end
   end
 
+  def mock_registerd_app(&block)
+    @app = mock_app do
+      register Sinatra::StrongParams
+      class_eval(&block)
+    end
+  end
+
   def app
     @app
   end


### PR DESCRIPTION
This changes will improve the error message for a needed param to include the missing keys. The new error message will be something like: `One or more required parameters were missing: id, name, action`

Besides this change, I also refactored the specs a bit to remove some duplications and updated the README.

Please check @evanleck 