### PR TITLE
Bump to version 0.1.0 and add Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2019-01-27
+
+### Added
+- Now you don't need to explicitly allow the needed params anymore when using `needs` and `allows` combined.
+
+### Changed
+- The error message for missing needed params now includes a list of the missing ones.
+
+### Fixed
+- When using `allows`, the params hash keys was changing from string to symbol.
+
+## [0.0.3] - 2017-01-30
+
+### Added
+- Gem test setup and basic tests.
+
+## [0.0.2] - 2015-11-12
+
+### Added
+- Accept `missing_parameter_message` configuration for missing needed params error message.
+
+## [0.0.1] - 2014-07-12
+
+### Added
+- Gem created.

--- a/lib/sinatra/strong-params/version.rb
+++ b/lib/sinatra/strong-params/version.rb
@@ -2,6 +2,6 @@
 # frozen_string_literal: true
 module Sinatra
   module StrongParams
-    VERSION = '0.0.3'
+    VERSION = '0.1.0'
   end
 end

--- a/sinatra-strong-params.gemspec
+++ b/sinatra-strong-params.gemspec
@@ -7,10 +7,9 @@ require 'sinatra/strong-params/version'
 Gem::Specification.new do |spec|
   spec.name          = 'sinatra-strong-params'
   spec.version       = Sinatra::StrongParams::VERSION
-  spec.authors       = ['Evan Lecklider']
-  spec.email         = ['evan@lecklider.com']
-  spec.summary       = 'Some super basic strong parameter filters for Sinatra.'
-  spec.description   = spec.summary
+  spec.authors       = ['Evan Lecklider', 'Gustavo Sobral']
+  spec.email         = ['evan@lecklider.com', 'ghsobral@gmail.com']
+  spec.summary       = 'Basic strong parameter filters for Sinatra.'
   spec.homepage      = 'https://github.com/evanleck/sinatra-strong-params'
   spec.license       = 'MIT'
 


### PR DESCRIPTION
I decided to bump the gem version and go from 0.0.3 to 0.1.0, since we made a good set of changes and the gem is quite stable. Besides that, I also added a Changelog. Can you please review it @evanleck? I'm not a native english speaker. I will create a v0.1.0 tag after this PR gets merged.

One question, do you mind if I join you in the gempsec list of authors? I would be very honored. 🙇 

Cheers